### PR TITLE
Fix for publications issues and other hotfixes (#11)

### DIFF
--- a/Controller/Webhook/Index.php
+++ b/Controller/Webhook/Index.php
@@ -100,7 +100,7 @@ class Index extends Action implements CsrfAwareActionInterface
             $charge = $body['data']['object'];
             if (isset($charge['payment_status']) && $charge['payment_status'] === "paid") {
                 try {
-                    $order = $this->orderInterface->loadByIncrementId($charge['metadata']['checkout_id']);
+                    $order = $this->orderInterface->loadByIncrementId($charge['metadata']['order_id']);
                     if (!$order->getId()) {
                         $this->_conektaLogger->error(
                             'Controller Index :: execute - The order does not allow an invoice to be created'

--- a/Gateway/Request/CreditCard/CaptureRequest.php
+++ b/Gateway/Request/CreditCard/CaptureRequest.php
@@ -51,6 +51,8 @@ class CaptureRequest implements BuilderInterface
                 $token
             );
             $request['metadata'] = [
+                'plugin' => 'Magento',
+                'plugin_version' => $this->_conektaHelper->getMageVersion(),
                 'order_id'       => $order->getOrderIncrementId(),
                 'soft_validations'  => 'true'
             ];

--- a/Gateway/Request/CreditCard/RefundBuilder.php
+++ b/Gateway/Request/CreditCard/RefundBuilder.php
@@ -34,6 +34,11 @@ class RefundBuilder implements BuilderInterface
         $order = $payment->getOrder();
         $amount =  $this->subjectReader->readAmount($buildSubject);
 
+        $request['metadata'] = [
+            'plugin' => 'Magento',
+            'plugin_version' => $this->_conektaHelper->getMageVersion()
+        ];
+
         $request = [
             'payment_transaction_id' => $order->getExtOrderId(),
             'payment_transaction_amount' => $amount

--- a/Gateway/Request/LineItemsBuilder.php
+++ b/Gateway/Request/LineItemsBuilder.php
@@ -45,7 +45,39 @@ class LineItemsBuilder implements BuilderInterface
         $request = [];
         $items = $order->getItems();
         foreach ($items as $itemId => $item) {
-            if ($version > 233) {
+            
+            if ($version > 240) {
+                if ($item->getProductType() != 'bundle' && $item->getProductType() != 'configurable') {
+                    
+                    $price = $item->getPrice();
+                    if ($price == 0 && !empty($item->getParentItem())) {
+                        $price = $item->getParentItem()->getPrice();
+                    }
+
+                    $request['line_items'][] = [
+                        'name' => $item->getName(),
+                        'sku' => $item->getSku(),
+                        'unit_price' => (int)($price * 100),
+                        'description' => $this->_escaper->escapeHtml($item->getName() . ' - ' . $item->getSku()),
+                        'quantity' => (int)($item->getQtyOrdered()),
+                        'tags' => [
+                            $item->getProductType()
+                        ]
+                    ];
+
+                    $this->_conektaLogger->info('Request LineItemsBuilder :: build', [
+                        'name' => $item->getName(),
+                        'sku' => $item->getSku(),
+                        'unit_price' => $price * 100,
+                        'quantity' => (int)($item->getQtyOrdered()),
+                        'tags' => [
+                            $item->getProductType()
+                        ]
+                    ]);
+
+                }
+            } elseif ($version > 233) {
+                
                 if ($item->getProductType() != 'bundle' && $item->getProductType() != 'configurable') {
                     $request['line_items'][] = [
                         'name' => $item->getName(),

--- a/Gateway/Request/Oxxo/AuthorizeRequest.php
+++ b/Gateway/Request/Oxxo/AuthorizeRequest.php
@@ -49,6 +49,8 @@ class AuthorizeRequest implements BuilderInterface
         $amount = (int)$order->getGrandTotalAmount();
 
         $request['metadata'] = [
+            'plugin' => 'Magento',
+            'plugin_version' => $this->_conektaHelper->getMageVersion(),
             'order_id'       => $order->getOrderIncrementId(),
             'soft_validations'  => 'true'
         ];

--- a/Gateway/Request/ShippingLinesBuilder.php
+++ b/Gateway/Request/ShippingLinesBuilder.php
@@ -2,6 +2,7 @@
 namespace Conekta\Payments\Gateway\Request;
 
 use Conekta\Payments\Logger\Logger as ConektaLogger;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
@@ -36,14 +37,14 @@ class ShippingLinesBuilder implements BuilderInterface
         $quote_id = $payment->getAdditionalInformation('quote_id');
         $quote = $this->_cartRepository->get($quote_id);
         $amount = $quote->getShippingAddress()->getShippingAmount();
-
-        if (!empty($amount)) {
+        
+        if (isset($amount) && $amount >= 0) {
             $shipping_lines['amount'] = (int)($amount * 100);
             $shipping_lines['method'] = $quote->getShippingAddress()->getShippingMethod();
             $shipping_lines['carrier'] = $quote->getShippingAddress()->getShippingDescription();
             $request['shipping_lines'][] = $shipping_lines;
         } else {
-            $request['shipping_lines'] = [];
+            throw new LocalizedException(__('Shippment information should be provided'));
         }
 
         $this->_conektaLogger->info('Request ShippingLinesBuilder :: build : return request', $request);

--- a/Gateway/Request/Spei/AuthorizeRequest.php
+++ b/Gateway/Request/Spei/AuthorizeRequest.php
@@ -42,6 +42,8 @@ class AuthorizeRequest implements BuilderInterface
         $amount = (int)$order->getGrandTotalAmount();
 
         $request['metadata'] = [
+            'plugin' => 'Magento',
+            'plugin_version' => $this->_conektaHelper->getMageVersion(),
             'order_id'       => $order->getOrderIncrementId(),
             'soft_validations'  => 'true'
         ];

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -6,6 +6,7 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Module\ModuleListInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class Data extends AbstractHelper
 {
@@ -15,16 +16,20 @@ class Data extends AbstractHelper
 
     protected $_productMetadata;
 
+    private $_storeManager;
+
     public function __construct(
         Context $context,
         ModuleListInterface $moduleList,
         EncryptorInterface $encryptor,
-        ProductMetadataInterface $productMetadata
+        ProductMetadataInterface $productMetadata,
+        StoreManagerInterface $storeManager
     ) {
         parent::__construct($context);
         $this->_moduleList = $moduleList;
         $this->_encryptor = $encryptor;
         $this->_productMetadata = $productMetadata;
+        $this->_storeManager = $storeManager;
     }
 
     public function getConfigData($area, $field, $storeId = null)
@@ -105,5 +110,15 @@ class Data extends AbstractHelper
         $attributesArray = explode(",", $attributes);
         
         return $attributesArray;
+    }
+
+    public function getUrlWebhookOrDefault()
+    {
+        $urlWebhook = $this->getConfigData('conekta/conekta_global', 'conekta_webhook');
+        if (empty($urlWebhook)) {
+            $baseUrl = $this->_storeManager->getStore()->getBaseUrl();
+            $urlWebhook = $baseUrl . "conekta/webhook/listener";
+        }
+        return $urlWebhook;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,14 @@
     "name": "conekta/conekta_payments",
     "description": "Conekta payment gateway",
     "require": {
-        "magento/module-sales": "^101.0.0|^102.0.0",
-        "magento/module-checkout": "^100.2.0|^100.3.0",
-        "magento/module-payment": "^100.2.0|^100.3.0",
-        "magento/framework": "^101.0.0|^102.0.0",
+        "magento/module-sales": "^101.0.0|^102.0.0|^103.0.2",
+        "magento/module-checkout": "^100.2.0|^100.3.0|^100.4.2",
+        "magento/module-payment": "^100.2.0|^100.3.0|^100.4.2",
+        "magento/framework": "^101.0.0|^102.0.0|^103.0.2",
         "conekta/conekta-php": "*"
     },
     "type": "magento2-module",
-    "version": "3.0.0",
+    "version": "3.5.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -32,13 +32,13 @@
                         <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     </field>
                     <!-- // Key's Setup // -->
-                    <field id="conekta_webhook" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <field id="conekta_webhook" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
                         <label>Webhook</label>
                         <comment>
                             <![CDATA[Default webhook is: <strong>your_magento_host/conekta/webhook/listener</strong>]]>
                         </comment>
                     </field>
-                    <field id="debug" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="debug" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0" >
                         <label>Debug</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     </field>

--- a/view/base/templates/info/oxxo.phtml
+++ b/view/base/templates/info/oxxo.phtml
@@ -18,7 +18,7 @@ $data = $block->getDataOxxo();
             <tr>
                 <th><strong><?= /* @noEscape */ __('Expires at:'); ?></strong></th>
                 <td>
-                    <?= $block->escapeHtml($data['expires_at']); ?>
+                    <?= $block->escapeHtml(date("Y-m-d", (integer) $data["expires_at"])); ?>
                 </td>
             </tr>
             </tbody>


### PR DESCRIPTION
* 0079709 - setting credit card order id in metadata

* 0079706 - setting select days or hours

* 0079706 - sending timestamp to conekta

* 0082915 - getting product attributes in select

* 0082915 - validating and trying to get order attributes

* 0082915 - getting selected attributes from config

* 0082915 - sending product attributes to Conekta

* 0082915 - getting order attributes, trying to get values

* 0082915 - getting quote values

* 0082915 - clean code and testing

* 0082915 - filter id and converting integers values to string

* 003596 - formating booleans and gender

* 0083596 - gender to lowercase

* 0083596 - cleaning code and fixing attribute

* remove al magento dependencies required to test magento 2.4

* required dependencies for magento 2.4 added

* 80198- message modified

* solves the issue of those order-items that are simple product of a configurable product type and return price 0 for magento 2.4

* 0084467 - Magento Version added to metada transactions

* indentation fixes

* Info template views coding standarized

* Coding standard applied

* Coding standard applied

* end of line added

* oxxo order expire date formatted

* remove RefundBuilder empty line to meet standard

* allow free shipping

* coding standard applied

* add Notification Observer

* add correction of charge metadata subindex checkout_id for order_id

* avoid webhook existing exception

* udpate version composer

* avoid exception when try to update webhook with no private keys

* listen for events in the stored webhook

* magento dependencies updated

* cast price fixed

* 0085553 - middle version plugin updated

Co-authored-by: Mauricio <mauricio@serfe.com>
Co-authored-by: pablo <pablo@serfe.com>
Co-authored-by: lucianop <lucianop@serfe.com>
Co-authored-by: leandro <leandro@serfe.com>
Co-authored-by: Gaston <gaston@serfe.com>